### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -13,6 +13,7 @@
         <language>de</language>
         <description lang="en">Cooking videos</description>
         <description lang="de">Video Kochrezepte</description>
+        <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <website>http://www.chefkoch.de</website>
         <source>https://github.com/AddonScriptorDE/plugin.video.chefkoch_de</source>
         <forum>http://forum.xbmc.org/showthread.php?tid=132563</forum>


### PR DESCRIPTION
Needed to automatically fill field on http://kodi.wiki and http://addons.kodi.tv/ sites.
